### PR TITLE
Fix codecov CI and update template

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,23 +1,23 @@
 {
-    "template": "https://github.com/scverse/cookiecutter-scverse",
-    "commit": "7cc5403b05e299d7a4bb169c2bd8c27a2a7676f3",
-    "checkout": null,
-    "context": {
-        "cookiecutter": {
-            "project_name": "simple-scvi",
-            "package_name": "simple_scvi",
-            "project_description": "External and simple implementation of scVI",
-            "author_full_name": "Adam Gayoso",
-            "author_email": "adamgayoso@berkeley.edu",
-            "github_user": "adamgayoso",
-            "project_repo": "https://github.com/scverse/simple-scvi",
-            "license": "BSD 3-Clause License",
-            "_copy_without_render": [
-                ".github/workflows/**.yaml",
-                "docs/_templates/autosummary/**.rst"
-            ],
-            "_template": "https://github.com/scverse/cookiecutter-scverse"
-        }
-    },
-    "directory": null
+  "template": "https://github.com/scverse/cookiecutter-scverse",
+  "commit": "c21b82bf134f3a0f13db7482d4fb04ca1f562d59",
+  "checkout": "main",
+  "context": {
+    "cookiecutter": {
+      "project_name": "simple-scvi",
+      "package_name": "simple_scvi",
+      "project_description": "External and simple implementation of scVI",
+      "author_full_name": "Adam Gayoso",
+      "author_email": "adamgayoso@berkeley.edu",
+      "github_user": "adamgayoso",
+      "project_repo": "https://github.com/scverse/simple-scvi",
+      "license": "BSD 3-Clause License",
+      "_copy_without_render": [
+        ".github/workflows/**.yaml",
+        "docs/_templates/autosummary/**.rst"
+      ],
+      "_template": "https://github.com/scverse/cookiecutter-scverse"
+    }
+  },
+  "directory": null
 }

--- a/.cruft.json
+++ b/.cruft.json
@@ -1,23 +1,23 @@
 {
-  "template": "https://github.com/scverse/cookiecutter-scverse",
-  "commit": "c21b82bf134f3a0f13db7482d4fb04ca1f562d59",
-  "checkout": "main",
-  "context": {
-    "cookiecutter": {
-      "project_name": "simple-scvi",
-      "package_name": "simple_scvi",
-      "project_description": "External and simple implementation of scVI",
-      "author_full_name": "Adam Gayoso",
-      "author_email": "adamgayoso@berkeley.edu",
-      "github_user": "adamgayoso",
-      "project_repo": "https://github.com/scverse/simple-scvi",
-      "license": "BSD 3-Clause License",
-      "_copy_without_render": [
-        ".github/workflows/**.yaml",
-        "docs/_templates/autosummary/**.rst"
-      ],
-      "_template": "https://github.com/scverse/cookiecutter-scverse"
-    }
-  },
-  "directory": null
+    "template": "https://github.com/scverse/cookiecutter-scverse",
+    "commit": "c21b82bf134f3a0f13db7482d4fb04ca1f562d59",
+    "checkout": "main",
+    "context": {
+        "cookiecutter": {
+            "project_name": "simple-scvi",
+            "package_name": "simple_scvi",
+            "project_description": "External and simple implementation of scVI",
+            "author_full_name": "Adam Gayoso",
+            "author_email": "adamgayoso@berkeley.edu",
+            "github_user": "adamgayoso",
+            "project_repo": "https://github.com/scverse/simple-scvi",
+            "license": "BSD 3-Clause License",
+            "_copy_without_render": [
+                ".github/workflows/**.yaml",
+                "docs/_templates/autosummary/**.rst"
+            ],
+            "_template": "https://github.com/scverse/cookiecutter-scverse"
+        }
+    },
+    "directory": null
 }

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,8 +8,8 @@ body:
               **Note**: Please read [this guide](https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports)
               detailing how to provide the necessary information for us to reproduce your bug. In brief:
                 * Please provide exact steps how to reproduce the bug in a clean Python environment.
-                * In case it's not clear what's causing this bug, please provide the data or the data generation procecure.
-                * Sometimes it is not possible to share the data but usually it is possible to replicate problems on publicly
+                * In case it's not clear what's causing this bug, please provide the data or the data generation procedure.
+                * Sometimes it is not possible to share the data, but usually it is possible to replicate problems on publicly
                   available datasets or to share a subset of your data.
 
     - type: textarea

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,15 +6,21 @@ on:
     pull_request:
         branches: [main]
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     package:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Set up Python 3.10
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: "3.10"
+                  cache: "pip"
+                  cache-dependency-path: "**/pyproject.toml"
             - name: Install build dependencies
               run: python -m pip install --upgrade pip wheel twine build
             - name: Build package

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -43,4 +43,4 @@ jobs:
                       manually merge these changes.**
 
                       For more information about the template sync, please refer to the
-                      [template documentation](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/developer_docs.html#automated-template-sync).
+                      [template documentation](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#automated-template-sync).

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,10 @@ on:
     pull_request:
         branches: [main]
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     test:
         runs-on: ${{ matrix.os }}
@@ -24,27 +28,17 @@ jobs:
             PYTHON: ${{ matrix.python }}
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Set up Python ${{ matrix.python }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python }}
+                  cache: "pip"
+                  cache-dependency-path: "**/pyproject.toml"
 
-            - name: Get pip cache dir
-              id: pip-cache-dir
-              run: |
-                  echo "::set-output name=dir::$(pip cache dir)"
-            - name: Restore pip cache
-              uses: actions/cache@v2
-              with:
-                  path: ${{ steps.pip-cache-dir.outputs.dir }}
-                  key: pip-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml') }}
-                  restore-keys: |
-                      pip-${{ runner.os }}-${{ env.pythonLocation }}-
             - name: Install test dependencies
               run: |
                   python -m pip install --upgrade pip wheel
-                  pip install codecov
             - name: Install dependencies
               run: |
                   pip install ".[dev,test]"
@@ -56,7 +50,4 @@ jobs:
               run: |
                   pytest -v --cov --color=yes
             - name: Upload coverage
-              env:
-                  CODECOV_NAME: ${{ matrix.python }}-${{ matrix.os }}
-              run: |
-                  codecov --required --flags=unittests
+              uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,13 @@
 # Temp files
 .DS_Store
 *~
+buck-out/
 
 # Compiled files
+.venv/
 __pycache__/
+.mypy_cache/
+.ruff_cache/
 
 # Distribution / packaging
 /build/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,32 +7,28 @@ default_stages:
 minimum_pre_commit_version: 2.16.0
 repos:
     - repo: https://github.com/psf/black
-      rev: 23.3.0
+      rev: "23.3.0"
       hooks:
           - id: black
-    - repo: https://github.com/pre-commit/mirrors-prettier
-      rev: v3.0.0-alpha.6
-      hooks:
-          - id: prettier
     - repo: https://github.com/asottile/blacken-docs
       rev: 1.13.0
       hooks:
           - id: blacken-docs
-    - repo: https://github.com/PyCQA/isort
-      rev: 5.12.0
+    - repo: https://github.com/pre-commit/mirrors-prettier
+      rev: v3.0.0-alpha.6
       hooks:
-          - id: isort
-    - repo: https://github.com/asottile/yesqa
-      rev: v1.4.0
+          - id: prettier
+            # Newer versions of node don't work on systems that have an older version of GLIBC
+            # (in particular Ubuntu 18.04 and Centos 7)
+            # EOL of Centos 7 is in 2024-06, we can probably get rid of this then.
+            # See https://github.com/scverse/cookiecutter-scverse/issues/143 and
+            # https://github.com/jupyterlab/jupyterlab/issues/12675
+            language_version: "17.9.1"
+    - repo: https://github.com/charliermarsh/ruff-pre-commit
+      rev: v0.0.261
       hooks:
-          - id: yesqa
-            additional_dependencies:
-                - flake8-tidy-imports
-                - flake8-docstrings
-                - flake8-rst-docstrings
-                - flake8-comprehensions
-                - flake8-bugbear
-                - flake8-blind-except
+          - id: ruff
+            args: [--fix, --exit-non-zero-on-fix]
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.4.0
       hooks:

--- a/.pre-commit-config.yaml.rej
+++ b/.pre-commit-config.yaml.rej
@@ -1,0 +1,33 @@
+diff a/.pre-commit-config.yaml b/.pre-commit-config.yaml	(rejected hunks)
+@@ -43,31 +39,6 @@ repos:
+             args: [--fix=lf]
+           - id: trailing-whitespace
+           - id: check-case-conflict
+-    - repo: https://github.com/myint/autoflake
+-      rev: v2.0.2
+-      hooks:
+-          - id: autoflake
+-            args:
+-                - --in-place
+-                - --remove-all-unused-imports
+-                - --remove-unused-variable
+-                - --ignore-init-module-imports
+-    - repo: https://github.com/PyCQA/flake8
+-      rev: 6.0.0
+-      hooks:
+-          - id: flake8
+-            additional_dependencies:
+-                - flake8-tidy-imports
+-                - flake8-docstrings
+-                - flake8-rst-docstrings
+-                - flake8-comprehensions
+-                - flake8-bugbear
+-                - flake8-blind-except
+-    - repo: https://github.com/asottile/pyupgrade
+-      rev: v3.3.1
+-      hooks:
+-          - id: pyupgrade
+-            args: [--py3-plus, --py38-plus, --keep-runtime-typing]
+     - repo: local
+       hooks:
+           - id: forbid-to-commit

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -39,9 +39,6 @@ Attributes
 
 {% for item in attributes %}
 
-{{ item }}
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 .. autoattribute:: {{ [objname, item] | join(".") }}
 {%- endfor %}
 
@@ -55,9 +52,6 @@ Methods
 
 {% for item in methods %}
 {%- if item != '__init__' %}
-
-{{ item }}
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automethod:: {{ [objname, item] | join(".") }}
 {%- endif -%}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,12 +16,15 @@ sys.path.insert(0, str(HERE / "extensions"))
 
 # -- Project information -----------------------------------------------------
 
+# NOTE: If you installed your project in editable mode, this might be stale.
+#       If this is the case, reinstall it to refresh the metadata
 info = metadata("simple-scvi")
 project_name = info["Name"]
 author = info["Author"]
 copyright = f"{datetime.now():%Y}, {author}."
 version = info["Version"]
-repository_url = f"https://github.com/adamgayoso/{project_name}"
+urls = dict(pu.split(", ") for pu in info.get_all("Project-URL"))
+repository_url = urls["Source"]
 
 # The full version, including alpha/beta/rc tags
 release = info["Version"]
@@ -65,7 +68,7 @@ napoleon_numpy_docstring = True
 napoleon_include_init_with_doc = False
 napoleon_use_rtype = True  # having a separate entry generally helps readability
 napoleon_use_param = True
-myst_heading_anchors = 3  # create anchors for h1-h3
+myst_heading_anchors = 6  # create anchors for h1-h6
 myst_enable_extensions = [
     "amsmath",
     "colon_fence",
@@ -87,6 +90,7 @@ source_suffix = {
 }
 
 intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
     "anndata": ("https://anndata.readthedocs.io/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
 }
@@ -109,6 +113,7 @@ html_title = project_name
 html_theme_options = {
     "repository_url": repository_url,
     "use_repository_button": True,
+    "path_to_docs": "docs/",
 }
 
 pygments_style = "default"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -142,6 +142,7 @@ Please write documentation for new or changed features and use-cases. This proje
 -   [Numpy-style docstrings][numpydoc] (through the [napoloen][numpydoc-napoleon] extension).
 -   Jupyter notebooks as tutorials through [myst-nb][] (See [Tutorials with myst-nb](#tutorials-with-myst-nb-and-jupyter-notebooks))
 -   [Sphinx autodoc typehints][], to automatically reference annotated input and output types
+-   Citations (like {cite:p}`Virshup_2023`) can be included with [sphinxcontrib-bibtex](https://sphinxcontrib-bibtex.readthedocs.io/)
 
 See the [scanpy developer docs](https://scanpy.readthedocs.io/en/latest/dev/documentation.html) for more information
 on how to write documentation.

--- a/docs/extensions/typed_returns.py
+++ b/docs/extensions/typed_returns.py
@@ -1,24 +1,27 @@
 # code from https://github.com/theislab/scanpy/blob/master/docs/extensions/typed_returns.py
 # with some minor adjustment
+from __future__ import annotations
+
 import re
+from collections.abc import Generator, Iterable
 
 from sphinx.application import Sphinx
 from sphinx.ext.napoleon import NumpyDocstring
 
 
-def _process_return(lines):
+def _process_return(lines: Iterable[str]) -> Generator[str, None, None]:
     for line in lines:
-        m = re.fullmatch(r"(?P<param>\w+)\s+:\s+(?P<type>[\w.]+)", line)
-        if m:
-            # Once this is in scanpydoc, we can use the fancy hover stuff
+        if m := re.fullmatch(r"(?P<param>\w+)\s+:\s+(?P<type>[\w.]+)", line):
             yield f'-{m["param"]} (:class:`~{m["type"]}`)'
         else:
             yield line
 
 
-def _parse_returns_section(self, section):
-    lines_raw = list(_process_return(self._dedent(self._consume_to_next_section())))
-    lines = self._format_block(":returns: ", lines_raw)
+def _parse_returns_section(self: NumpyDocstring, section: str) -> list[str]:
+    lines_raw = self._dedent(self._consume_to_next_section())
+    if lines_raw[0] == ":":
+        del lines_raw[0]
+    lines = self._format_block(":returns: ", list(_process_return(lines_raw)))
     if lines and lines[-1]:
         lines.append("")
     return lines

--- a/docs/template_usage.md
+++ b/docs/template_usage.md
@@ -131,6 +131,10 @@ If your project is private, there are ways to enable docs rendering on [readthed
 check code for errors, inconsistencies and code styles, before the code
 is committed.
 
+This template uses a number of pre-commit checks. In this section we'll detail what is used, where they're defined, and how to modify these checks.
+
+#### Pre-commit CI
+
 We recommend setting up [pre-commit.ci][] to enforce consistency checks on every commit
 and pull-request.
 
@@ -142,78 +146,116 @@ Once authorized, pre-commit.ci should automatically be activated.
 
 #### Overview of pre-commit hooks used by the template
 
-The following pre-commit checks are for code style and format:
+The following pre-commit hooks are for code style and format:
 
--   [black](https://black.readthedocs.io/en/stable/): standard code
-    formatter in Python.
--   [isort](https://pycqa.github.io/isort/): sort module imports into
-    sections and types.
--   [prettier](https://prettier.io/docs/en/index.html): standard code
-    formatter for non-Python files (e.g. YAML).
--   [blacken-docs](https://github.com/asottile/blacken-docs): black on
-    python code in docs.
-
-The following pre-commit checks are for errors and inconsistencies:
-
--   [flake8](https://flake8.pycqa.org/en/latest/): standard check for errors in Python files.
-    -   [flake8-tidy-imports](https://github.com/adamchainz/flake8-tidy-imports):
-        tidy module imports.
-    -   [flake8-docstrings](https://github.com/PyCQA/flake8-docstrings):
+-   [black](https://black.readthedocs.io/en/stable/):
+    standard code formatter in Python.
+-   [blacken-docs](https://github.com/asottile/blacken-docs):
+    black on Python code in docs.
+-   [prettier](https://prettier.io/docs/en/index.html):
+    standard code formatter for non-Python files (e.g. YAML).
+-   [ruff][] based checks:
+    -   [isort](https://beta.ruff.rs/docs/rules/#isort-i) (rule category: `I`):
+        sort module imports into sections and types.
+    -   [pydocstyle](https://beta.ruff.rs/docs/rules/#pydocstyle-d) (rule category: `D`):
         pydocstyle extension of flake8.
-    -   [flake8-rst-docstrings](https://github.com/peterjc/e8-rst-docstrings):
-        extension of `flake8-docstrings` for `rst` docs.
-    -   [flake8-comprehensions](https://github.com/adamchainz/e8-comprehensions):
+    -   [flake8-tidy-imports](https://beta.ruff.rs/docs/rules/#flake8-tidy-imports-tid) (rule category: `TID`):
+        tidy module imports.
+    -   [flake8-comprehensions](https://beta.ruff.rs/docs/rules/#flake8-comprehensions-c4) (rule category: `C4`):
         write better list/set/dict comprehensions.
-    -   [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear):
-        find possible bugs and design issues in program.
-    -   [flake8-blind-except](https://github.com/elijahandrews/flake8-blind-except):
-        checks for blind, catch-all `except` statements.
--   [yesqa](https://github.com/asottile/yesqa):
-    remove unneccesary `# noqa` comments, follows additional dependencies listed above.
--   [autoflake](https://github.com/PyCQA/autoflake):
-    remove unused imports and variables.
--   [pre-commit-hooks](https://github.com/pre-commit/pre-commit-hooks): generic pre-commit hooks.
+    -   [pyupgrade](https://beta.ruff.rs/docs/rules/#pyupgrade-up) (rule category: `UP`):
+        upgrade syntax for newer versions of the language.
+
+The following pre-commit hooks are for errors and inconsistencies:
+
+-   [pre-commit-hooks](https://github.com/pre-commit/pre-commit-hooks): generic pre-commit hooks for text files.
     -   **detect-private-key**: checks for the existence of private keys.
     -   **check-ast**: check whether files parse as valid python.
-    -   **end-of-file-fixer**:check files end in a newline and only a newline.
+    -   **end-of-file-fixer**: check files end in a newline and only a newline.
     -   **mixed-line-ending**: checks mixed line ending.
     -   **trailing-whitespace**: trims trailing whitespace.
     -   **check-case-conflict**: check files that would conflict with case-insensitive file systems.
--   [pyupgrade](https://github.com/asottile/pyupgrade):
-    upgrade syntax for newer versions of the language.
--   **forbid-to-commit**: Make sure that `*.rej` files cannot be commited. These files are created by the
-    [automated template sync](#automated-template-sync) if there's a merge conflict and need to be addressed manually.
+    -   **forbid-to-commit**: Make sure that `*.rej` files cannot be commited.
+        These files are created by the [automated template sync](#automated-template-sync)
+        if there's a merge conflict and need to be addressed manually.
+-   [ruff][] based checks:
+    -   [pyflakes](https://beta.ruff.rs/docs/rules/#pyflakes-f) (rule category: `F`):
+        various checks for errors.
+    -   [pycodestyle](https://beta.ruff.rs/docs/rules/#pycodestyle-e-w) (rule category: `E`, `W`):
+        various checks for errors.
+    -   [flake8-bugbear](https://beta.ruff.rs/docs/rules/#flake8-bugbear-b) (rule category: `B`):
+        find possible bugs and design issues in program.
+    -   [flake8-blind-except](https://beta.ruff.rs/docs/rules/#flake8-blind-except-ble) (rule category: `BLE`):
+        checks for blind, catch-all `except` statements.
+    -   [Ruff-specific rules](https://beta.ruff.rs/docs/rules/#ruff-specific-rules-ruf) (rule category: `RUF`):
+        -   `RUF100`: remove unneccesary `# noqa` comments ()
 
-### How to disable or add pre-commit checks
+#### How to add or remove pre-commit checks
 
--   To ignore lint warnigs from **flake8**, see [Ignore certain lint warnings](#how-to-ignore-certain-lint-warnings).
--   You can add or remove pre-commit checks by simply deleting relevant lines in the `.pre-commit-config.yaml` file.
-    Some pre-commit checks have additional options that can be specified either in the `pyproject.toml` or tool-specific
-    config files, such as `.prettierrc.yml` for **prettier** and `.flake8` for **flake8**.
-
-### How to ignore certain lint warnings
-
-The [pre-commit checks](#pre-commit-checks) include [flake8](https://flake8.pycqa.org/en/latest/) which checks
-for errors in Python files, including stylistic errors.
-
+The [pre-commit checks](#pre-commit-checks) check for both correctness and stylistic errors.
 In some cases it might overshoot and you may have good reasons to ignore certain warnings.
+This section shows you where these checks are defined, and how to enable/ disable them.
 
-To ignore an specific error on a per-case basis, you can add a comment `# noqa` to the offending line. You can also
-specify the error ID to ignore, with e.g. `# noqa: E731`. Check the [flake8 guide][] for reference.
+##### pre-commit
 
-Alternatively, you can disable certain error messages for the entire project. To do so, edit the `.flake8`
-file in the root of the repository. Add one line per linting code you wish to ignore and don't forget to add a comment.
+You can add or remove pre-commit checks by simply deleting relevant lines in the `.pre-commit-config.yaml` file under the repository root.
+Some pre-commit checks have additional options that can be specified either in the `pyproject.toml` (for `ruff` and `black`) or tool-specific
+config files, such as `.prettierrc.yml` for **prettier**.
+
+##### Ruff
+
+This template configures `ruff` through the `[tool.ruff]` entry in the `pyproject.toml`.
+For further information `ruff` configuration, see [the docs](https://beta.ruff.rs/docs/configuration/).
+
+Ruff assigns code to the rules it checks (e.g. `E401`) and groups them under a rule category (e.g. `E`).
+Rule categories are selectively enabled by including them under the `select` key:
 
 ```toml
+[tool.ruff]
 ...
-# line break before a binary operator -> black does not adhere to PEP8
-W503
-# line break occured after a binary operator -> black does not adhere to PEP8
-W504
-...
+
+select = [
+    "F",  # Errors detected by Pyflakes
+    "E",  # Error detected by Pycodestyle
+    "W",  # Warning detected by Pycodestyle
+    "I",  # isort
+    ...
+]
 ```
 
-[flake8 guide]: https://flake8.pycqa.org/en/3.1.1/user/ignoring-errors.html
+The `ignore` entry is used to disable specific rules for the entire project.
+Add the rule code(s) you want to ignore and don't forget to add a comment explaining why.
+You can find a long list of checks that this template disables by default sitting there already.
+
+```toml
+ignore = [
+    ...
+    # __magic__ methods are are often self-explanatory, allow missing docstrings
+    "D105",
+    ...
+]
+```
+
+Checks can be ignored per-file (or glob pattern) with `[tool.ruff.per-file-ignores]`.
+
+```toml
+[tool.ruff.per-file-ignores]
+"docs/*" = ["I"]
+"tests/*" = ["D"]
+"*/__init__.py" = ["F401"]
+```
+
+To ignore a specific rule on a per-case basis, you can add a `# noqa: <rule>[, <rule>, …]` comment to the offending line.
+Specify the rule code(s) to ignore, with e.g. `# noqa: E731`. Check the [Ruff guide][] for reference.
+
+```{note}
+The `RUF100` check will remove rule codes that are no longer necessary from `noqa` comments.
+If you want to add a code that comes from a tool other than Ruff,
+add it to Ruff’s [`external = [...]`](https://beta.ruff.rs/docs/settings/#external) setting to prevent `RUF100` from removing it.
+```
+
+[ruff]: https://beta.ruff.rs/docs/
+[ruff guide]: https://beta.ruff.rs/docs/configuration/#suppressing-errors
 
 ### API design
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 build-backend = "hatchling.build"
 requires = ["hatchling"]
 
-
 [project]
 name = "simple-scvi"
 version = "0.0.1"
@@ -37,7 +36,7 @@ dev = [
 ]
 doc = [
     "sphinx>=4",
-    "sphinx-book-theme>=0.3.3",
+    "sphinx-book-theme>=1.0.0",
     "myst-nb",
     "sphinxcontrib-bibtex>=1.0.0",
     "sphinx-autodoc-typehints",
@@ -64,32 +63,62 @@ addopts = [
     "--import-mode=importlib",  # allow using test files with same name
 ]
 
-[tool.isort]
-include_trailing_comma = true
-multi_line_output = 3
-profile = "black"
-skip_glob = ["docs/*"]
-
 [tool.black]
 line-length = 120
-target-version = ['py38']
-include = '\.pyi?$'
-exclude = '''
-(
-  /(
-      \.eggs
-    | \.git
-    | \.hg
-    | \.mypy_cache
-    | \.tox
-    | \.venv
-    | _build
-    | buck-out
-    | build
-    | dist
-  )/
-)
-'''
+target-version = ["py38"]
+
+[tool.ruff]
+src = ["src"]
+line-length = 120
+target-version = "py38"
+select = [
+    "F",  # Errors detected by Pyflakes
+    "E",  # Error detected by Pycodestyle
+    "W",  # Warning detected by Pycodestyle
+    "I",  # isort
+    "D",  # pydocstyle
+    "B",  # flake8-bugbear
+    "TID",  # flake8-tidy-imports
+    "C4",  # flake8-comprehensions
+    "BLE",  # flake8-blind-except
+    "UP",  # pyupgrade
+    "RUF100",  # Report unused noqa directives
+]
+ignore = [
+    # line too long -> we accept long comment lines; black gets rid of long code lines
+    "E501",
+    # Do not assign a lambda expression, use a def -> lambda expression assignments are convenient
+    "E731",
+    # allow I, O, l as variable names -> I is the identity matrix
+    "E741",
+    # Missing docstring in public package
+    "D104",
+    # Missing docstring in public module
+    "D100",
+    # Missing docstring in __init__
+    "D107",
+    # Errors from function calls in argument defaults. These are fine when the result is immutable.
+    "B008",
+    # __magic__ methods are are often self-explanatory, allow missing docstrings
+    "D105",
+    # first line should end with a period [Bug: doesn't work with single-line docstrings]
+    "D400",
+    # First line should be in imperative mood; try rephrasing
+    "D401",
+    ## Disable one in each pair of mutually incompatible rules
+    # We don’t want a blank line before a class docstring
+    "D203",
+    # We want docstrings to start immediately after the opening triple quote
+    "D213",
+]
+
+[tool.ruff.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.per-file-ignores]
+"docs/*" = ["I"]
+"tests/*" = ["D"]
+"*/__init__.py" = ["F401"]
 
 [tool.jupytext]
 formats = "ipynb,md"

--- a/src/simple_scvi/_mymodule.py
+++ b/src/simple_scvi/_mymodule.py
@@ -93,7 +93,7 @@ class MyModule(BaseModuleClass):
         """Parse the dictionary to get appropriate args"""
         x = tensors[REGISTRY_KEYS.X_KEY]
 
-        input_dict = dict(x=x)
+        input_dict = {"x": x}
         return input_dict
 
     def _get_generative_input(self, tensors, inference_outputs):
@@ -119,7 +119,7 @@ class MyModule(BaseModuleClass):
         qz_m, qz_v, z = self.z_encoder(x_)
         ql_m, ql_v, library = self.l_encoder(x_)
 
-        outputs = dict(z=z, qz_m=qz_m, qz_v=qz_v, ql_m=ql_m, ql_v=ql_v, library=library)
+        outputs = {"z": z, "qz_m": qz_m, "qz_v": qz_v, "ql_m": ql_m, "ql_v": ql_v, "library": library}
         return outputs
 
     @auto_move_data
@@ -129,7 +129,7 @@ class MyModule(BaseModuleClass):
         px_scale, _, px_rate, px_dropout = self.decoder("gene", z, library)
         px_r = torch.exp(self.px_r)
 
-        return dict(px_scale=px_scale, px_r=px_r, px_rate=px_rate, px_dropout=px_dropout)
+        return {"px_scale": px_scale, "px_r": px_r, "px_rate": px_rate, "px_dropout": px_dropout}
 
     def loss(
         self,
@@ -174,7 +174,7 @@ class MyModule(BaseModuleClass):
 
         loss = torch.mean(reconst_loss + weighted_kl_local)
 
-        kl_local = dict(kl_divergence_l=kl_divergence_l, kl_divergence_z=kl_divergence_z)
+        kl_local = {"kl_divergence_l": kl_divergence_l, "kl_divergence_z": kl_divergence_z}
         return LossOutput(loss=loss, reconstruction_loss=reconst_loss, kl_local=kl_local)
 
     @torch.no_grad()
@@ -202,7 +202,7 @@ class MyModule(BaseModuleClass):
         x_new
             tensor with shape (n_cells, n_genes, n_samples)
         """
-        inference_kwargs = dict(n_samples=n_samples)
+        inference_kwargs = {"n_samples": n_samples}
         (
             _,
             generative_outputs,

--- a/src/simple_scvi/_mypyromodel.py
+++ b/src/simple_scvi/_mypyromodel.py
@@ -94,6 +94,8 @@ class MyPyroModel(BaseModelClass):
             Indices of cells in adata to use. If `None`, all cells are used.
         batch_size
             Minibatch size for data loading into model. Defaults to `scvi.settings.batch_size`.
+
+
         Returns
         -------
         latent_representation : np.ndarray
@@ -145,7 +147,7 @@ class MyPyroModel(BaseModelClass):
             n_cells = self.adata.n_obs
             max_epochs = np.min([round((20000 / n_cells) * 400), 400])
 
-        plan_kwargs = plan_kwargs if isinstance(plan_kwargs, dict) else dict()
+        plan_kwargs = plan_kwargs if isinstance(plan_kwargs, dict) else {}
 
         data_splitter = DataSplitter(
             self.adata_manager,


### PR DESCRIPTION
This PR fixes some problems with the CI setup of the scverse-cookiecutter template repo. Last night, [the `codecov` package was pulled from PyPI](https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259). This can easily be replaced, however we've realized our automatic template sync system does not allow us to modify github actions (a security precaution from github), so we need to roll out this update manually.

We're also taking this opportunity to make several other intended changes for to the CI workflow.

We're still looking into how we can avoid this in the future, which will likely require us changing how our template sync system works. This is being tracked in the [scverse/cookiecutter-scverse#138](https://www.github.com/scverse/cookiecutter-scverse/issues/138). 

## Changes

These changes constitute the 0.2.1 release of the template and make the following changes:

* Remove codecov as a dependency since it's been pulled from pypi ([scverse/cookiecutter-scverse#161](https://www.github.com/scverse/cookiecutter-scverse/pull/161))
* Remove usage of deprecated GitHub actions environment variables (these will be removed in a month) ([scverse/cookiecutter-scverse#161](https://www.github.com/scverse/cookiecutter-scverse/pull/161))
* Fix some spurious ruff errors ([scverse/cookiecutter-scverse#156](https://www.github.com/scverse/cookiecutter-scverse/pull/156), [scverse/cookiecutter-scverse#159](https://www.github.com/scverse/cookiecutter-scverse/pull/159))
* Replace the example citation with the scverse manuscript ([scverse/cookiecutter-scverse#160](https://www.github.com/scverse/cookiecutter-scverse/pull/160))
* automatically cancel running CI jobs on new commit ( [scverse/cookiecutter-scverse#158](https://www.github.com/scverse/cookiecutter-scverse/pull/158))

## Additional remarks
* If there are **merge conflicts**, they either show up inline (`>>>>>>>`) or a `.rej` file will have been created for the respective files. You need to address these conflicts manually. Make sure to enable pre-commit.ci (see below) to detect such files.
* The scverse template works best when the [pre-commit.ci](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#pre-commit-ci), [readthedocs](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#documentation-on-readthedocs) and [codecov](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#coverage-tests-with-codecov) services are enabled. Make sure to activate those apps if you haven't already. 
